### PR TITLE
Update referredBy handling

### DIFF
--- a/api/controllers/ReferralController.js
+++ b/api/controllers/ReferralController.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-
   /**
    * Finds a user's referral code and the number of people they've successfully
    * referred. If a referral code isn't found, then it generates one and saves
@@ -13,15 +12,15 @@ module.exports = {
     let resBody = {
       phone: phone,
       referralCode: '',
-      referralCount: 0
-    }
+      referralCount: 0,
+    };
 
     // Find this user by the phone number
-    User.findOne({phone: phone})
+    User.findOne({ phone: phone })
       .then(function(result) {
         // Throw an error if the user's not found
         if (typeof result === 'undefined') {
-          throw new Error;
+          throw new Error();
         }
 
         // If there's already a referral code, add to the response. Otherwise,
@@ -29,8 +28,7 @@ module.exports = {
         let createCode = false;
         if (result.referralCode) {
           resBody.referralCode = result.referralCode;
-        }
-        else {
+        } else {
           createCode = true;
         }
 
@@ -45,12 +43,17 @@ module.exports = {
           resBody.referralCode = code;
 
           // Update in the database
-          return User.update({phone: phone}, {referralCode: code});
+          return User.update({ phone: phone }, { referralCode: code });
         }
       })
       // Get the number of people the user has successfully referred
       .then(function(results) {
-        return User.count({referredBy: phone});
+        return User.count({
+          referredBy: phone,
+          mobilecommonsStatus: { '!': ['Profiles with no Subscriptions'] },
+        });
+        // Note: In actual use, the above also seems to take care of cases where
+        // mobilecommonsStatus is undefined. But it doesn't in unit tests.
       })
       // Add the count to the response and send
       .then(function(result) {
@@ -62,9 +65,8 @@ module.exports = {
       .catch(function(error) {
         return res.json(404, {
           phone: phone,
-          error: 'Unable to retrieve referral information for this user'
+          error: 'Unable to retrieve referral information for this user',
         });
       });
-  }
-
+  },
 };

--- a/api/controllers/SignupController.js
+++ b/api/controllers/SignupController.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-
   /**
    * Handles a signup submission. Upserts the user and decodes the referral code
    * to the referredBy property if a code is provided.
@@ -11,7 +10,11 @@ module.exports = {
     let firstName = req.body.firstName;
     let phone = PhoneUtils.transformForDb(req.body.phone);
 
-    if (typeof firstName === 'undefined' || phone === null || phone.length !== 11) {
+    if (
+      typeof firstName === 'undefined' ||
+      phone === null ||
+      phone.length !== 11
+    ) {
       return res.json(400, 'Invalid first name and/or phone number');
     }
 
@@ -28,54 +31,51 @@ module.exports = {
     }
 
     // Upsert the user with the provided info
-    User.findOne({phone: phone})
+    User.findOne({ phone: phone })
       .then(function(result) {
         let user = {
           firstName: firstName,
-          phone: phone
+          phone: phone,
         };
 
         if (email) {
           user.email = email;
         }
 
-        if (referredBy) {
+        if (referredBy && (!result || !result.referredBy)) {
           user.referredBy = referredBy;
         }
 
         // Generate referral code for new user or an existing one that doesn't
         // yet have one set.
-        if (! result || ! result.referralCode) {
+        if (!result || !result.referralCode) {
           user.referralCode = ReferralCodes.encode(phone);
         }
 
         if (result) {
-          return User.update({phone: phone}, user);
-        }
-        else {
+          return User.update({ phone: phone }, user);
+        } else {
           return User.create(user);
         }
       })
       .then(function(result) {
-        if (! result) {
-          throw new Error;
+        if (!result) {
+          throw new Error();
         }
 
         // Result from an update is an array
         if (result.length > 0) {
           return res.json(result[0]);
-        }
-        // Result from a create is the user object
-        else {
+        } else {
+          // Result from a create is the user object
           return res.json(result);
         }
       })
       .catch(function(error) {
         sails.log.error(error);
         return res.json(500, {
-          error: 'There was an error in processing the signup'
+          error: 'There was an error in processing the signup',
         });
       });
   },
-
 };

--- a/api/controllers/SignupController.js
+++ b/api/controllers/SignupController.js
@@ -42,7 +42,14 @@ module.exports = {
           user.email = email;
         }
 
-        if (referredBy && (!result || !result.referredBy)) {
+        // The referredBy value can be updated if it has not yet been set, or if
+        // the user has not yet subscribed to Mobile Commons.
+        const canUpdateReferredBy =
+          !result ||
+          !result.referredBy ||
+          (!result.mobilecommonsStatus ||
+            result.mobilecommonsStatus !== 'Profiles with no Subscriptions');
+        if (referredBy && canUpdateReferredBy) {
           user.referredBy = referredBy;
         }
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -7,36 +7,40 @@ module.exports = {
 
   // Only specifying properties that can be used by and exposed to client apps
   attributes: {
-
     email: {
       columnName: 'email',
       type: 'string',
-      size: 128
+      size: 128,
     },
 
     firstName: {
       columnName: 'first_name',
       type: 'string',
-      size: 64
+      size: 64,
     },
 
     phone: {
       columnName: 'phone_number',
       type: 'string',
-      size: 11
+      size: 11,
     },
 
     referralCode: {
       columnName: 'referral_code',
       type: 'string',
-      size: 11
+      size: 11,
     },
 
     referredBy: {
       columnName: 'referred_by',
       type: 'string',
-      size: 11
-    }
+      size: 11,
+    },
 
-  }
+    mobilecommonsStatus: {
+      columnName: 'mobilecommons_status',
+      type: 'string',
+      size: 64,
+    },
+  },
 };

--- a/test/fixtures/user.json
+++ b/test/fixtures/user.json
@@ -7,6 +7,7 @@
   },
   {
     "firstName": "User.test.B",
+    "mobilecommonsStatus": "Active Subscriber",
     "phone": "15555550102",
     "referralCode": null,
     "referredBy": "15555550101"
@@ -40,5 +41,12 @@
     "phone": "15555550111",
     "referralCode": null,
     "referredBy": null
+  },
+  {
+    "firstName": "SignupController.test.notYetSubscribed",
+    "mobilecommonsStatus": "Profiles with no Subscriptions",
+    "phone": "15555550111",
+    "referralCode": null,
+    "referredBy": "ABC123"
   }
 ]

--- a/test/fixtures/user.json
+++ b/test/fixtures/user.json
@@ -45,8 +45,19 @@
   {
     "firstName": "SignupController.test.notYetSubscribed",
     "mobilecommonsStatus": "Profiles with no Subscriptions",
-    "phone": "15555550111",
+    "phone": "15555550112",
     "referralCode": null,
-    "referredBy": "ABC123"
+    "referredBy": "15555550114"
+  },
+  {
+    "firstName": "ReferralController.test.subscribed",
+    "mobilecommonsStatus": "Active Subscriber",
+    "phone": "15555550113",
+    "referredBy": "15555550114"
+  },
+  {
+    "firstName": "ReferralController.test.referredNotYetSubscribed",
+    "mobilecommonsStatus": "Active Subscriber",
+    "phone": "15555550114"
   }
 ]

--- a/test/integration/controllers/ReferralController.test.js
+++ b/test/integration/controllers/ReferralController.test.js
@@ -1,21 +1,19 @@
 var assert = require('assert');
 var Barrels = require('barrels');
-var fixtures = (new Barrels()).data;
+var fixtures = new Barrels().data;
 var request = require('supertest');
 
 describe('ReferralController', function() {
-
   describe('#findOne() with an invalid number', function() {
     it('should respond with a 404', function(done) {
-      request(sails.hooks.http.app)
-        .get('/referral/5555550199')
-        .expect(
-          404,
-          {
-            phone: '15555550199',
-            error: 'Unable to retrieve referral information for this user'
-          },
-          done);
+      request(sails.hooks.http.app).get('/referral/5555550199').expect(
+        404,
+        {
+          phone: '15555550199',
+          error: 'Unable to retrieve referral information for this user',
+        },
+        done
+      );
     });
   });
 
@@ -54,4 +52,17 @@ describe('ReferralController', function() {
     });
   });
 
+  describe('#findOne() on user who referred a not-yet-subscribed user', function() {
+    it('should not count that user towards their referral', function(done) {
+      // Two test users have 15555550114 set as their referredBy. But only one
+      // is marked as an active subscriber
+      request(sails.hooks.http.app)
+        .get(`/referral/15555550114`)
+        .expect(200)
+        .expect(function(res) {
+          assert.equal(res.body.referralCount, 1);
+        })
+        .end(done);
+    });
+  });
 });

--- a/test/integration/controllers/SignupController.test.js
+++ b/test/integration/controllers/SignupController.test.js
@@ -145,6 +145,28 @@ describe('SignupController', function() {
     });
   });
 
+  describe('#signup() not-yet-subscribed user with new referredBy value', function() {
+    it('should update to the new referredBy value', function(done) {
+      request(sails.hooks.http.app)
+        .post('/signup')
+        .send({
+          phone: '15555550112',
+          referredByCode: 'qMoyyeg',
+        })
+        .expect(200)
+        .expect(function(res) {
+          assert.equal(res.body.referredBy, '15555550101');
+        })
+        .end(function() {
+          var phone = PhoneUtils.transformForDb(userSignupNewReferredBy.phone);
+          User.findOne({ phone: phone }).then(function(result) {
+            assert.equal(result.referredBy, '15555550101');
+            done();
+          });
+        });
+    });
+  });
+
   describe('#signup() new user with email', function() {
     it('should save the user with the email', function(done) {
       var expectedCode = ReferralCodes.encode(userSignupEmail.phone);


### PR DESCRIPTION
#### What's this PR do?
This modifies the logic around when it's ok to update a User.referredBy value. The meat of the change starts at line 47 of SignupController.js. Basically, we only want to set/update the referredBy value of a user if they don't yet have one set, or if they're not yet subscribed to any Mobile Commons campaigns.

Additionally, since some users may not yet have successfully subscribed, but could have a `referredBy` set, we're updating the count query in ReferralController.js to account for that.

#### More context
This is being done in response to changes happening on the [aurora repo](https://github.com/shinetext/aurora/pull/156) where it'll start creating user rows for betas/friends invited to Shine. And it _should_ cover edge case problems where referredBy values were at risk of getting overwritten.