### PR TITLE
added alpha user's id in resBody in get/referral/:phone route

### DIFF
--- a/api/controllers/ReferralController.js
+++ b/api/controllers/ReferralController.js
@@ -10,7 +10,7 @@ module.exports = {
     let phone = PhoneUtils.transformForDb(req.params.phone);
 
     let resBody = {
-      id: '',
+      id: undefined,
       phone: phone,
       referralCode: '',
       referralCount: 0

--- a/api/controllers/ReferralController.js
+++ b/api/controllers/ReferralController.js
@@ -10,9 +10,10 @@ module.exports = {
     let phone = PhoneUtils.transformForDb(req.params.phone);
 
     let resBody = {
+      id: '',
       phone: phone,
       referralCode: '',
-      referralCount: 0,
+      referralCount: 0
     };
 
     // Find this user by the phone number
@@ -22,6 +23,9 @@ module.exports = {
         if (typeof result === 'undefined') {
           throw new Error();
         }
+
+        // set user id in response body
+        resBody.id = result.id;
 
         // If there's already a referral code, add to the response. Otherwise,
         // set flag indicating that one will need to be created.
@@ -67,8 +71,8 @@ module.exports = {
       .catch(function(error) {
         return res.json(404, {
           phone: phone,
-          error: 'Unable to retrieve referral information for this user',
+          error: 'Unable to retrieve referral information for this user'
         });
       });
-  },
+  }
 };

--- a/test/fixtures/user.json
+++ b/test/fixtures/user.json
@@ -1,11 +1,13 @@
 [
   {
+    "id": 1,
     "firstName": "User.test.A",
     "phone": "15555550101",
     "referralCode": "qMoyyeg",
     "referredBy": null
   },
   {
+    "id": 2,
     "firstName": "User.test.B",
     "mobilecommonsStatus": "Active Subscriber",
     "phone": "15555550102",
@@ -13,36 +15,42 @@
     "referredBy": "15555550101"
   },
   {
+    "id": 3,
     "firstName": "User.test.C",
     "phone": "15555550103",
     "referralCode": null,
     "referredBy": "15555550101"
   },
   {
+    "id": 4,
     "firstName": "User.test.update",
     "phone": "15555550104",
     "referralCode": null,
     "referredBy": null
   },
   {
+    "id": 4,
     "firstName": "ReferralController.test.noCode",
     "phone": "15555550105",
     "referralCode": null,
     "referredBy": null
   },
   {
+    "id": 6,
     "firstName": "SignupController.test.referrer",
     "phone": "15555550110",
     "referralCode": "Opl22M3",
     "referredBy": null
   },
   {
+    "id": 7,
     "firstName": "SignupController.test.update",
     "phone": "15555550111",
     "referralCode": null,
     "referredBy": null
   },
   {
+    "id": 8,
     "firstName": "SignupController.test.notYetSubscribed",
     "mobilecommonsStatus": "Profiles with no Subscriptions",
     "phone": "15555550120",
@@ -50,12 +58,14 @@
     "referredBy": "15555550122"
   },
   {
+    "id": 9,
     "firstName": "ReferralController.test.subscribed",
     "mobilecommonsStatus": "Active Subscriber",
     "phone": "15555550121",
     "referredBy": "15555550122"
   },
   {
+    "id": 10,
     "firstName": "ReferralController.test.referredNotYetSubscribed",
     "mobilecommonsStatus": "Active Subscriber",
     "phone": "15555550122"

--- a/test/integration/controllers/ReferralController.test.js
+++ b/test/integration/controllers/ReferralController.test.js
@@ -14,7 +14,7 @@ describe('ReferralController', function() {
           404,
           {
             phone: '15555550199',
-            error: 'Unable to retrieve referral information for this user',
+            error: 'Unable to retrieve referral information for this user'
           },
           done
         );
@@ -45,6 +45,7 @@ describe('ReferralController', function() {
         .get('/referral/' + user.phone)
         .expect(200)
         .expect(function(res) {
+          assert.equal(res.body.id, user.id);
           assert.equal(res.body.phone, user.phone);
           assert.equal(res.body.referralCode, user.referralCode);
           assert.equal(res.body.referralCount, 2); // User.test.B and User.test.C
@@ -81,6 +82,7 @@ describe('ReferralController', function() {
         .get('/referral/' + user.phone)
         .expect(200)
         .expect(function(res) {
+          assert.equal(res.body.id, user.id);
           assert.equal(res.body.phone, user.phone);
           assert.equal(res.body.referralCode, expectedCode);
           assert.equal(res.body.referralCount, 0);
@@ -109,8 +111,8 @@ describe('ReferralController', function() {
         assert.deepEqual(params, [phone]);
         callback(undefined, [
           {
-            count: 1,
-          },
+            count: 1
+          }
         ]);
       };
 


### PR DESCRIPTION
#### What's this PR do?
- Added alpha user's id in resBody when GET/referral/:phone route
- user id is needed in Aurora when packaging data to be published to `referral` SNS event
 
 #### How was this tested?
 - Locally `npm run start` and Postman makes requests to the endpoint

 #### What are the relevant tickets?
 
 #### Questions / Considerations
